### PR TITLE
Resolve tft.readID returning 0x0 or 0xC0C0 on TFT 2.4  LCD

### DIFF
--- a/examples/graphicstest/graphicstest.pde
+++ b/examples/graphicstest/graphicstest.pde
@@ -57,7 +57,10 @@ void setup(void) {
 
   tft.reset();
 
-  tft.begin(0x9341);
+  uint16_t id;
+  id = tft.readID();
+  Serial.print("ChipID is 0x");Serial.println(id, HEX);
+  tft.begin(id);
 
   Serial.println(F("Benchmark                Time (microseconds)"));
 

--- a/examples/rotationtest/rotationtest.pde
+++ b/examples/rotationtest/rotationtest.pde
@@ -55,7 +55,10 @@ void setup(void) {
 
   tft.reset();
 
-  tft.begin(0x9341);
+  uint16_t id;
+  id = tft.readID();
+  Serial.print("ChipID is 0x");Serial.println(id, HEX);
+  tft.begin(id);
 
   tft.fillScreen(BLACK);
 

--- a/src/TftSpfd5408.cpp
+++ b/src/TftSpfd5408.cpp
@@ -929,7 +929,7 @@ uint32_t TftSpfd5408::readReg(uint8_t r) {
   write8(r);
   setReadDir();  // Set up LCD data port(s) for READ operations
   CD_DATA;
-  delayMicroseconds(50);
+  delayMicroseconds(500);
   read8(x);
   id = x;          // Do not merge or otherwise simplify
   id <<= 8;              // these lines.  It's an unfortunate

--- a/src/pin_magic.h
+++ b/src/pin_magic.h
@@ -176,11 +176,6 @@
     DELAY7;                                           \
     result = ((PINH & B00011000) << 3) | ((PINE & B00001000) << 2) | ((PING & B00100000) >> 1) |((PINE & B00110000) >> 2) | ((PINH & B01100000) >> 5); \
     RD_IDLE; }
-  #define read8inline(result) { \
-    RD_ACTIVE;                  \
-    DELAY7;                     \
-    result = PINA;              \
-    RD_IDLE; }
   // Changed to works with SPFD5408, based in post by Buhosoft (http://forum.arduino.cc/index.php?topic=292777.0)
   #define setWriteDirInline() { DDRE |=  B00111000; DDRG |=  B00100000; DDRH |= B01111000;}
   // Changed to works with SPFD5408, based in post by Buhosoft (http://forum.arduino.cc/index.php?topic=292777.0)


### PR DESCRIPTION
The code has been tested with Mega2560.

