### PR TITLE
Use semver compliant version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SPFD5408 TFT Library
-version=dev
+version=1.1.0
 author=Sadika Sumanapala
 maintainer=Sadika Sumanapala
 sentence=TFT library for SPFD5408

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SPFD5408 TFT Library
-version=1.1.0
+version=1.2.0
 author=Sadika Sumanapala
 maintainer=Sadika Sumanapala
 sentence=TFT library for SPFD5408


### PR DESCRIPTION
Non-semver compliant `version` value causes the Arduino IDE to display warnings:
```
Invalid version found: dev
```
This can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

References:
- https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format
- https://semver.org/