### PR TITLE
modified textsize initialization to textsize_x and textsize_y

### DIFF
--- a/src/TftSpfd5408.cpp
+++ b/src/TftSpfd5408.cpp
@@ -110,12 +110,12 @@ void TftSpfd5408::init(void) {
 
   setWriteDir(); // Set up LCD data port(s) for WRITE operations
 
-  rotation  = 0;
-  cursor_y  = cursor_x = 0;
-  textsize  = 1;
-  textcolor = 0xFFFF;
-  _width    = TFTWIDTH;
-  _height   = TFTHEIGHT;
+  rotation   = 0;
+  cursor_y   = cursor_x = 0;
+  textsize_x = textsize_y = 1;
+  textcolor  = 0xFFFF;
+  _width     = TFTWIDTH;
+  _height    = TFTHEIGHT;
 }
 
 // Initialization command tables for different LCD controllers


### PR DESCRIPTION
According to Adafruit GFX change from version 1.5.3 to version 1.5.4 and following the member variable textsize changed to individual variables textsize_x and textsize_y. This issue is discussed in issue #4

I tested the code with:
- Adafruit GFX 1.10.4
- Arduino IDE 1.8.12
- The TFTLCD-SPFD5408 library from the master branch including my commit
- Examples: graphicstest, rotationtest, tftpaint
- Arduino Uno
- SPFD5408-TFT-Shield

I also tested TFTLCD_SPFD5408 V1.1.0 with Adafruit GFX 1.5.3 for comparison

The driver compiles again without errors and runs on the Arduino as expected.
I would be glad if you can create a new release to be included in the Arduino-Library.
